### PR TITLE
Rename thread link to comments link

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -121,7 +121,7 @@
   "share": "Share...",
   "text": "Text",
   "link": "Link",
-  "threadLink": "Thread link",
+  "threadLink": "Comments link",
   "userLink": "User link",
   "copySuccess": "{option} has been copied",
   "markRead": "Mark read",


### PR DESCRIPTION
The sharing menu provides the option to share either the Link (story) or Thread link (comments). The HN API calls comments kids, but the website calls them comments. I think calling them comments in the share menu clarifies any ambiguity about which item is which.