### PR TITLE
Open hackernewsletter links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,17 +43,11 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:scheme="http"
-                    android:host="news.ycombinator.com"
-                    android:pathPrefix="/item" />
-                <data
                     android:scheme="https"
                     android:host="news.ycombinator.com"
                     android:pathPrefix="/item" />
                 <data
                     android:scheme="http"
-                    android:host="news.ycombinator.com"
-                    android:pathPrefix="/user" />
-                <data
                     android:scheme="https"
                     android:host="news.ycombinator.com"
                     android:pathPrefix="/user" />
@@ -64,8 +58,6 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:scheme="http"
-                    android:host="hackernewsletter.us1.list-manage.com" />
-                <data
                     android:scheme="https"
                     android:host="hackernewsletter.us1.list-manage.com" />
             </intent-filter>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,6 +58,17 @@
                     android:host="news.ycombinator.com"
                     android:pathPrefix="/user" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="http"
+                    android:host="hackernewsletter.us1.list-manage.com" />
+                <data
+                    android:scheme="https"
+                    android:host="hackernewsletter.us1.list-manage.com" />
+            </intent-filter>
         </activity>
         <meta-data
             android:name="flutterEmbedding"


### PR DESCRIPTION
I subscribe to the [hackernewsletter](https://hackernewsletter.com/) and would find convenient for Glider to open the links I receive by email instead of the phone's browser.
Haven't tested this change since I'm not sure on how to build the app locally.